### PR TITLE
Fix query string builder for GET requests with args

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -75,7 +75,10 @@ export default class LunchMoney {
 
 		let url = `${ base }${ endpoint }`;
 		if ( method === 'GET' && args ) {
-			url += '?' + Object.entries( args ).map( ( [ key, value ] ) => `${ key }=${ value }` )
+			url += '?';
+			url += Object.entries( args )
+									 .map( ( [ key, value ] ) => `${ key }=${ value }` )
+									 .join( "&" );
 		}
 		const headers = new Headers();
 		headers.set( 'Accept', '*/*' );

--- a/index.ts
+++ b/index.ts
@@ -78,7 +78,7 @@ export default class LunchMoney {
 			url += '?';
 			url += Object.entries( args )
 				.map( ( [ key, value ] ) => `${ key }=${ value }` )
-				.join( "&" );
+				.join( '&' );
 		}
 		const headers = new Headers();
 		headers.set( 'Accept', '*/*' );

--- a/index.ts
+++ b/index.ts
@@ -77,8 +77,8 @@ export default class LunchMoney {
 		if ( method === 'GET' && args ) {
 			url += '?';
 			url += Object.entries( args )
-									 .map( ( [ key, value ] ) => `${ key }=${ value }` )
-									 .join( "&" );
+				.map( ( [ key, value ] ) => `${ key }=${ value }` )
+				.join( "&" );
 		}
 		const headers = new Headers();
 		headers.set( 'Accept', '*/*' );


### PR DESCRIPTION
The string conversion from the mapped array was joining elements with commas, leading to a URL in the format `https://﻿example.com/?arg1=val1,arg2=val2`

This PR fixes the bug by calling join using '&' as a separator. The fix has been tested on a local script
