### PR TITLE
Add getPlaidAccounts method

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -6,6 +6,21 @@ export interface Asset {
     balance: number;
     institution_name?: string;
 }
+export interface PlaidAccount {
+    id: number;
+    date_linked: string;
+    name: string;
+    type: "credit" | "depository" | "brokerage" | "cash" | "loan" | "Investment";
+    subtype?: string;
+    mask: string;
+    institution_name: string;
+    status: "active" | "inactive" | "relink" | "syncing" | "error" | "not found" | "not supported";
+    last_import: string;
+    balance: number;
+    currency: string;
+    balance_last_update: string;
+    limit?: number;
+}
 export interface Transaction {
     id: number;
     date: string;
@@ -56,6 +71,7 @@ export default class LunchMoney {
     post(endpoint: string, args?: EndpointArguments): Promise<any>;
     request(method: "GET" | "POST" | "PUT" | "DELETE", endpoint: string, args?: EndpointArguments): Promise<any>;
     getAssets(): Promise<Asset[]>;
+    getPlaidAccounts(): Promise<PlaidAccount[]>;
     getTransactions(args?: TransactionsEndpointArguments): Promise<Transaction[]>;
     createTransactions(transactions: DraftTransaction[], applyRules?: boolean, checkForRecurring?: boolean, debitAsNegative?: boolean): Promise<any>;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,25 +1,30 @@
 export interface Asset {
     id: number;
-    type_name: string;
-    subtype_name?: string;
+    type_name: "employee compensation" | "cash" | "vehicle" | "loan" | "cryptocurrency" | "investment" | "other" | "credit" | "real estate";
+    subtype_name?: string | null;
     name: string;
-    balance: number;
-    institution_name?: string;
+    display_name?: string | null;
+    balance: string;
+    balance_as_of: string;
+    currency: string;
+    closed_on?: string | null;
+    institution_name?: string | null;
+    created_at: string;
 }
 export interface PlaidAccount {
     id: number;
     date_linked: string;
     name: string;
-    type: "credit" | "depository" | "brokerage" | "cash" | "loan" | "Investment";
-    subtype?: string;
+    type: "credit" | "depository" | "brokerage" | "cash" | "loan" | "investment";
+    subtype?: string | null;
     mask: string;
     institution_name: string;
     status: "active" | "inactive" | "relink" | "syncing" | "error" | "not found" | "not supported";
-    last_import: string;
-    balance: number;
+    last_import?: string | null;
+    balance: string;
     currency: string;
     balance_last_update: string;
-    limit?: number;
+    limit?: number | null;
 }
 export interface Transaction {
     id: number;

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,7 +32,10 @@ class LunchMoney {
         return __awaiter(this, void 0, void 0, function* () {
             let url = `${base}${endpoint}`;
             if (method === 'GET' && args) {
-                url += '?' + Object.entries(args).map(([key, value]) => `${key}=${value}`);
+                url += '?';
+                url += Object.entries(args)
+                    .map(([key, value]) => `${key}=${value}`)
+                    .join('&');
             }
             const headers = new Headers();
             headers.set('Accept', '*/*');
@@ -58,6 +61,11 @@ class LunchMoney {
     getAssets() {
         return __awaiter(this, void 0, void 0, function* () {
             return this.get('/v1/assets');
+        });
+    }
+    getPlaidAccounts() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return (yield this.get('/v1/plaid_accounts')).plaid_accounts;
         });
     }
     getTransactions(args) {

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,29 @@ export interface Asset {
 	institution_name?: string,
 }
 
+export interface PlaidAccount {
+  id: number;
+  date_linked: string;
+  name: string;
+  type: "credit" | "depository" | "brokerage" | "cash" | "loan" | "Investment";
+  subtype?: string;
+  mask: string;
+  institution_name: string;
+  status:
+    | "active"
+    | "inactive"
+    | "relink"
+    | "syncing"
+    | "error"
+    | "not found"
+    | "not supported";
+  last_import: string;
+  balance: number;
+  currency: string;
+  balance_last_update: string;
+  limit?: number;
+}
+
 export interface Transaction {
 	id: number,
 	date: string,
@@ -103,6 +126,10 @@ export default class LunchMoney {
 
 	async getAssets() : Promise<Asset[]> {
 		return this.get( '/v1/assets' );
+	}
+
+	async getPlaidAccounts() : Promise<PlaidAccount[]> {
+		return ( await this.get( '/v1/plaid_accounts' ) ).plaid_accounts;
 	}
 
 	async getTransactions( args?: TransactionsEndpointArguments ) : Promise<Transaction[]> {

--- a/index.ts
+++ b/index.ts
@@ -3,35 +3,48 @@ import fetch from 'isomorphic-fetch';
 const base = 'https://dev.lunchmoney.app';
 
 export interface Asset {
-	id: number,
-	type_name: string,
-	subtype_name?: string,
-	name: string,
-	balance: number,
-	institution_name?: string,
+	id: number;
+	type_name: "employee compensation"
+	  | "cash"
+	  | "vehicle"
+	  | "loan"
+	  | "cryptocurrency"
+	  | "investment"
+	  | "other"
+	  | "credit"
+	  | "real estate";
+	subtype_name?: string | null;
+	name: string;
+	display_name?: string | null;
+	balance: string;
+	balance_as_of: string;
+	currency: string;
+	closed_on?: string | null;
+	institution_name?: string | null;
+	created_at: string;
 }
 
 export interface PlaidAccount {
-  id: number;
-  date_linked: string;
-  name: string;
-  type: "credit" | "depository" | "brokerage" | "cash" | "loan" | "Investment";
-  subtype?: string;
-  mask: string;
-  institution_name: string;
-  status:
-    | "active"
-    | "inactive"
-    | "relink"
-    | "syncing"
-    | "error"
-    | "not found"
-    | "not supported";
-  last_import: string;
-  balance: number;
-  currency: string;
-  balance_last_update: string;
-  limit?: number;
+	id: number;
+	date_linked: string;
+	name: string;
+	type: "credit" | "depository" | "brokerage" | "cash" | "loan" | "investment";
+	subtype?: string | null;
+	mask: string;
+	institution_name: string;
+	status:
+	  | "active"
+	  | "inactive"
+	  | "relink"
+	  | "syncing"
+	  | "error"
+	  | "not found"
+	  | "not supported";
+	last_import?: string | null;
+	balance: string;
+	currency: string;
+	balance_last_update: string;
+	limit?: number | null;
 }
 
 export interface Transaction {


### PR DESCRIPTION
Copied the properties and their types straight from the documentation https://lunchmoney.dev/#plaid-accounts and mimicked the style of `getAssets()` and `getTransactions()` for consistency.

Also ran `npm run-script build` to update the dist/ directory. **Note**: that also pulled in the query string diff from https://github.com/lunch-money/lunch-money-js/pull/1