### PR TITLE
Add categories API, export LunchMoney explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 npm install lunch-money
 ```
 
-(waiting NPM approval, not yet working!)
-
 The NPM module also makes types available to TypeScript.
 
 ## Usage
@@ -24,15 +22,23 @@ lunchMoney.getAssets().then( ( assets: Asset[] ) => {
 } );
 ```
 
+Or, if you are using ESM:
+
+```javascript
+import {LunchMoney} from 'lunch-money'
+const lunchMoney = new LunchMoney( { token: 'my-api-token' } );
+const assets = await lunchMoney.getAssets();
+```
+
 ## API
 
-Get all assets
+Get all assets (manually managed accounts):
 
 ```typescript
 LunchMoney.getAssets() : Promise<Asset>
 ```
 
-Get all transactions
+Get all transactions:
 
 ```typescript
 LunchMoney.getTransactions( arguments?: TransactionsEndpointArguments ) : Promise<Transaction[]>
@@ -48,3 +54,9 @@ LunchMoney.createTransactions(
 	debitAsNegative = false
 ) : Promise<any>
 ```
+
+## Examples
+
+There are many open source projects with example code you can use to quickly build your integration:
+
+https://lunchmoney.dev/#awesome-projects

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -43,6 +43,18 @@ export interface Transaction {
     tags?: Tag;
     external_id?: string;
 }
+export interface Category {
+    id: number;
+    name: string;
+    description: string;
+    is_income: boolean;
+    exclude_from_budget: boolean;
+    exclude_from_totals: boolean;
+    updated_at: string;
+    created_at: string;
+    is_group: boolean;
+    group_id?: number;
+}
 export interface DraftTransaction {
     date: string;
     category_id?: number;
@@ -67,7 +79,7 @@ export interface TransactionsEndpointArguments {
 interface EndpointArguments {
     [s: string]: any;
 }
-export default class LunchMoney {
+export declare class LunchMoney {
     token: string;
     constructor(args: {
         token: string;
@@ -78,6 +90,7 @@ export default class LunchMoney {
     getAssets(): Promise<Asset[]>;
     getPlaidAccounts(): Promise<PlaidAccount[]>;
     getTransactions(args?: TransactionsEndpointArguments): Promise<Transaction[]>;
+    getCategories(): Promise<Category[]>;
     createTransactions(transactions: DraftTransaction[], applyRules?: boolean, checkForRecurring?: boolean, debitAsNegative?: boolean): Promise<any>;
 }
-export {};
+export default LunchMoney;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -74,6 +74,7 @@ export interface Tag {
 export interface TransactionsEndpointArguments {
     start_date?: string;
     end_date?: string;
+    tag_id?: number;
     debit_as_negative?: boolean;
 }
 interface EndpointArguments {
@@ -86,11 +87,13 @@ export declare class LunchMoney {
     });
     get(endpoint: string, args?: EndpointArguments): Promise<any>;
     post(endpoint: string, args?: EndpointArguments): Promise<any>;
+    delete(endpoint: string, args?: EndpointArguments): Promise<any>;
     request(method: "GET" | "POST" | "PUT" | "DELETE", endpoint: string, args?: EndpointArguments): Promise<any>;
     getAssets(): Promise<Asset[]>;
     getPlaidAccounts(): Promise<PlaidAccount[]>;
     getTransactions(args?: TransactionsEndpointArguments): Promise<Transaction[]>;
     getCategories(): Promise<Category[]>;
-    createTransactions(transactions: DraftTransaction[], applyRules?: boolean, checkForRecurring?: boolean, debitAsNegative?: boolean): Promise<any>;
+    createCategory(name: string, description: string, isIncome: boolean, excludeFromBudget: boolean, excludeFromTotals: boolean): Promise<any>;
+    createTransactions(transactions: DraftTransaction[], applyRules?: boolean, checkForRecurring?: boolean, debitAsNegative?: boolean, skipBalanceUpdate?: boolean): Promise<any>;
 }
 export default LunchMoney;

--- a/dist/index.js
+++ b/dist/index.js
@@ -29,6 +29,11 @@ class LunchMoney {
             return this.request('POST', endpoint, args);
         });
     }
+    delete(endpoint, args) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.request('DELETE', endpoint, args);
+        });
+    }
     request(method, endpoint, args) {
         return __awaiter(this, void 0, void 0, function* () {
             let url = `${base}${endpoint}`;
@@ -61,7 +66,7 @@ class LunchMoney {
     }
     getAssets() {
         return __awaiter(this, void 0, void 0, function* () {
-            return this.get('/v1/assets');
+            return (yield this.get('/v1/assets')).assets;
         });
     }
     getPlaidAccounts() {
@@ -79,13 +84,26 @@ class LunchMoney {
             return (yield this.get('/v1/categories')).categories;
         });
     }
-    createTransactions(transactions, applyRules = false, checkForRecurring = false, debitAsNegative = false) {
+    createCategory(name, description, isIncome, excludeFromBudget, excludeFromTotals) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const response = yield this.post('/v1/categories', {
+                name,
+                description,
+                is_income: isIncome,
+                exclude_from_budget: excludeFromBudget,
+                exclude_from_totals: excludeFromTotals
+            });
+            return response;
+        });
+    }
+    createTransactions(transactions, applyRules = false, checkForRecurring = false, debitAsNegative = false, skipBalanceUpdate = true) {
         return __awaiter(this, void 0, void 0, function* () {
             const response = yield this.post('/v1/transactions', {
                 transactions: transactions,
                 apply_rules: applyRules,
                 check_for_recurring: checkForRecurring,
-                debit_as_negative: debitAsNegative
+                debit_as_negative: debitAsNegative,
+                skip_balance_update: skipBalanceUpdate,
             });
             return response;
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -12,6 +12,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.LunchMoney = void 0;
 const isomorphic_fetch_1 = __importDefault(require("isomorphic-fetch"));
 const base = 'https://dev.lunchmoney.app';
 class LunchMoney {
@@ -48,7 +49,7 @@ class LunchMoney {
                 options.body = JSON.stringify(args);
                 headers.set('Content-Type', 'application/json');
             }
-            const response = yield isomorphic_fetch_1.default(url, options);
+            const response = yield (0, isomorphic_fetch_1.default)(url, options);
             if (response.status > 399) {
                 const r = yield response.text();
                 throw new Error(r);
@@ -73,6 +74,11 @@ class LunchMoney {
             return (yield this.get('/v1/transactions', args)).transactions;
         });
     }
+    getCategories() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return (yield this.get('/v1/categories')).categories;
+        });
+    }
     createTransactions(transactions, applyRules = false, checkForRecurring = false, debitAsNegative = false) {
         return __awaiter(this, void 0, void 0, function* () {
             const response = yield this.post('/v1/transactions', {
@@ -85,4 +91,5 @@ class LunchMoney {
         });
     }
 }
+exports.LunchMoney = LunchMoney;
 exports.default = LunchMoney;

--- a/index.ts
+++ b/index.ts
@@ -99,6 +99,7 @@ export interface Tag {
 export interface TransactionsEndpointArguments {
 	start_date?: string,
 	end_date?: string,
+	tag_id?: number,
 	debit_as_negative?: boolean,
 }
 
@@ -118,6 +119,10 @@ export class LunchMoney {
 
 	async post( endpoint: string, args?: EndpointArguments ) {
 		return this.request( 'POST', endpoint, args );
+	}
+
+	async delete(endpoint: string, args?: EndpointArguments) : Promise<any> {
+		return this.request( 'DELETE', endpoint, args );
 	}
 
 	async request( method: "GET" | "POST" | "PUT" | "DELETE", endpoint: string, args?: EndpointArguments ) {
@@ -151,7 +156,7 @@ export class LunchMoney {
 	}
 
 	async getAssets() : Promise<Asset[]> {
-		return this.get( '/v1/assets' );
+		return (await this.get( '/v1/assets' )).assets;
 	}
 
 	async getPlaidAccounts() : Promise<PlaidAccount[]> {
@@ -166,12 +171,25 @@ export class LunchMoney {
 		return ( await this.get( '/v1/categories' ) ).categories;
 	}
 
-	async createTransactions( transactions: DraftTransaction[], applyRules = false, checkForRecurring = false, debitAsNegative = false ) : Promise<any> {
+	async createCategory( name: string, description: string, isIncome: boolean, excludeFromBudget: boolean, excludeFromTotals: boolean ) : Promise<any> {
+		const response = await this.post( '/v1/categories', {
+			name,
+			description,
+			is_income: isIncome,
+			exclude_from_budget: excludeFromBudget,
+			exclude_from_totals: excludeFromTotals
+		} );
+
+		return response;
+	}
+
+	async createTransactions( transactions: DraftTransaction[], applyRules = false, checkForRecurring = false, debitAsNegative = false, skipBalanceUpdate = true ) : Promise<any> {
 		const response = await this.post( '/v1/transactions', {
 			transactions: transactions,
 			apply_rules: applyRules,
 			check_for_recurring: checkForRecurring,
-			debit_as_negative: debitAsNegative
+			debit_as_negative: debitAsNegative,
+			skip_balance_update: skipBalanceUpdate,
 		} );
 
 		return response;

--- a/index.ts
+++ b/index.ts
@@ -65,6 +65,19 @@ export interface Transaction {
 	external_id?: string,
 }
 
+export interface Category {
+	id:	number,
+	name:	string,
+	description:	string,
+	is_income:	boolean,
+	exclude_from_budget:	boolean,
+	exclude_from_totals:	boolean,
+	updated_at:	string,
+	created_at:	string,
+	is_group:	boolean,
+	group_id?: number,
+}
+
 export interface DraftTransaction {
 	date: string,
 	category_id?: number,
@@ -93,7 +106,7 @@ interface EndpointArguments {
 	[s: string]: any,
 }
 
-export default class LunchMoney {
+export class LunchMoney {
 	token: string;
 	constructor( args: { token: string } ) {
 		this.token = args.token;
@@ -149,6 +162,10 @@ export default class LunchMoney {
 		return ( await this.get( '/v1/transactions', args ) ).transactions;
 	}
 
+	async getCategories( ) : Promise<Category[]> {
+		return ( await this.get( '/v1/categories' ) ).categories;
+	}
+
 	async createTransactions( transactions: DraftTransaction[], applyRules = false, checkForRecurring = false, debitAsNegative = false ) : Promise<any> {
 		const response = await this.post( '/v1/transactions', {
 			transactions: transactions,
@@ -160,3 +177,6 @@ export default class LunchMoney {
 		return response;
 	}
 }
+
+
+export default LunchMoney;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,151 @@
+{
+  "name": "lunch-money",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lunch-money",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic-fetch": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/isomorphic-fetch": "^0.0.35",
+        "@types/node": "^16.11.0",
+        "typescript": "^4.4.4"
+      }
+    },
+    "node_modules/@types/isomorphic-fetch": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
+      "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.0.tgz",
+      "integrity": "sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg==",
+      "dev": true
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/isomorphic-fetch": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
+      "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.0.tgz",
+      "integrity": "sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg==",
+      "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lunch-money",
   "version": "0.0.1",
   "description": "",
+  "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -23,11 +24,11 @@
   "homepage": "https://github.com/lunch-money/lunch-money-js#readme",
   "devDependencies": {
     "@types/isomorphic-fetch": "^0.0.35",
-    "@types/node": "^13.9.3",
-    "typescript": "^3.8.3"
+    "@types/node": "^16.11.0",
+    "typescript": "^4.4.4"
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
   ],
   "author": "Joe Hoyle",
   "contributors": [
-    "Michael Bianco (https://mikebian.co/about)"
+    {
+      "name": "Michael Bianco",
+      "email": "mike@mikebian.co",
+      "url": "https://mikebian.co/about"
+    }
   ],
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "lunchmoney"
   ],
   "author": "Joe Hoyle",
+  "contributors": [
+    "Michael Bianco (https://mikebian.co/about)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/lunch-money/lunch-money-js/issues"


### PR DESCRIPTION
This fixes two main issues:

* Exports `LunchMoney` explicitly so it can be loaded from a ESM app via `import {LunchMoney} from 'lunch-money';`
* Adds support for the categories API

Also updated TypeScript and other dependencies. I think it would be great if we cut another release to npm as well.﻿
