### PR TITLE
feat: support other fetch functions and  Google app script platforms

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -126,8 +126,10 @@ interface EndpointArguments {
 }
 export declare class LunchMoney {
     token: string;
+    fetchFunc: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
     constructor(args: {
         token: string;
+        fetchFunc?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
     });
     get(endpoint: string, args?: EndpointArguments): Promise<any>;
     post(endpoint: string, args?: EndpointArguments): Promise<any>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -25,6 +25,12 @@ var TransactionStatus;
 class LunchMoney {
     constructor(args) {
         this.token = args.token;
+        if (args.fetchFunc) {
+            this.fetchFunc = args.fetchFunc;
+        }
+        else {
+            this.fetchFunc = isomorphic_fetch_1.default;
+        }
     }
     get(endpoint, args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -55,18 +61,19 @@ class LunchMoney {
                     .map(([key, value]) => `${key}=${value}`)
                     .join('&');
             }
-            const headers = new Headers();
-            headers.set('Accept', '*/*');
-            headers.set('Authorization', `Bearer ${this.token}`);
+            const headers = {
+                'Accept': '*/*',
+                'Authorization': `Bearer ${this.token}`
+            };
             const options = {
                 headers,
                 method,
             };
             if ((method === 'POST' || method === 'PUT') && args) {
                 options.body = JSON.stringify(args);
-                headers.set('Content-Type', 'application/json');
+                headers['Content-Type'] = 'application/json';
             }
-            const response = yield (0, isomorphic_fetch_1.default)(url, options);
+            const response = yield this.fetchFunc(url, options);
             if (response.status > 399) {
                 const r = yield response.text();
                 throw new Error(r);


### PR DESCRIPTION
Not sure if you're open to more features but I want to use your library in a Google Apps Script project so I need to make two changes.

- allows passing in a fetch function that conforms to expected types
    - Google Apps Script requires using their own fetch function for Google Apps Script projects. If your LunchMoney class took in that fetch function, I was able to pass in a wrapper that maps the differences and it works just fine. Theoretically, this could be useful for any platform that isomorphic-fetch doesn't support which could be useful.
- changes headers to be a 'any' object for platforms that don't have the Headers object
    - The Google Apps Script runtime doesn't have the Headers built-in object so I changed it to an any. I tested that this works in a node environment too.

Open to feedback!